### PR TITLE
Fix typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ You can access the Docker REST API through the socket file */coreos/var/run/dock
 
     # docker run -d -p 10050:10050 \
         -v /proc:/coreos/proc -v /sys:/coreos/sys -v /dev:/coreos/dev \
-        -v /var/run/docker.sock:/coreos/var/run/docker.sock
+        -v /var/run/docker.sock:/coreos/var/run/docker.sock \
         --name zabbix-coreos bhuisgen/docker-zabbix-coreos <HOSTNAME> <SERVER_IP>
 
 The needed arguments are:


### PR DESCRIPTION
Need a \ to wrap the line.